### PR TITLE
Ensure we only weakref() `obj` once

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -946,11 +946,10 @@ class singledispatchmethod:
 
     def __get__(self, obj, cls=None):
         caching = self._all_weakrefable_instances and obj is not None
-        cache = self._method_cache
 
         if caching:
             try:
-                _method = cache[obj]
+                _method = self._method_cache[obj]
             except TypeError:
                 self._all_weakrefable_instances = caching = False
             except KeyError:
@@ -967,7 +966,7 @@ class singledispatchmethod:
         update_wrapper(_method, self.func)
 
         if caching:
-            cache[obj] = _method
+            self._method_cache[obj] = _method
 
         return _method
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -945,17 +945,17 @@ class singledispatchmethod:
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):
-        caching = self._all_weakrefable_instances and obj is not None
-
-        if caching:
+        if self._all_weakrefable_instances and obj is not None:
             try:
                 _method = self._method_cache[obj]
             except TypeError:
                 self._all_weakrefable_instances = caching = False
             except KeyError:
-                pass
+                caching = True
             else:
                 return _method
+        else:
+            caching = False
 
         def _method(*args, **kwargs):
             method = self.dispatcher.dispatch(args[0].__class__)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -945,8 +945,18 @@ class singledispatchmethod:
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):
-        if self._all_weakrefable_instances and cls is not None and obj in self._method_cache:
-            return self._method_cache[obj]
+        caching = self._all_weakrefable_instances and obj is not None
+        cache = self._method_cache
+
+        if caching:
+            try:
+                _method = cache[obj]
+            except TypeError:
+                self._all_weakrefable_instances = caching = False
+            except KeyError:
+                pass
+            else:
+                return _method
 
         def _method(*args, **kwargs):
             method = self.dispatcher.dispatch(args[0].__class__)
@@ -956,11 +966,8 @@ class singledispatchmethod:
         _method.register = self.register
         update_wrapper(_method, self.func)
 
-        if self._all_weakrefable_instances and cls is not None:
-            try:
-                self._method_cache[obj] = _method
-            except TypeError:
-                self._all_weakrefable_instances = False
+        if caching:
+            cache[obj] = _method
 
         return _method
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2474,10 +2474,42 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertTrue(A.t(''))
         self.assertEqual(A.t(0.0), 0.0)
 
+    def test_slotted_class(self):
+        class Slot:
+            __slots__ = ('a', 'b')
+            @functools.singledispatchmethod
+            def go(self, item, arg):
+                pass
+
+            @go.register
+            def _(self, item: int, arg):
+                return item + arg
+
+        s = Slot()
+        self.assertEqual(s.go(1, 1), 2)
+
+    def test_classmethod_slotted_class(self):
+        class Slot:
+            __slots__ = ('a', 'b')
+            @functools.singledispatchmethod
+            @classmethod
+            def go(cls, item, arg):
+                pass
+
+            @go.register
+            @classmethod
+            def _(cls, item: int, arg):
+                return item + arg
+
+        s = Slot()
+        self.assertEqual(s.go(1, 1), 2)
+        self.assertEqual(Slot.go(1, 1), 2)
+
     def test_staticmethod_slotted_class(self):
         class A:
             __slots__ = ['a']
             @functools.singledispatchmethod
+            @staticmethod
             def t(arg):
                 return arg
             @t.register(int)


### PR DESCRIPTION
The performance characteristics of `WeakKeyDictionary()` seem pretty different to `dict`, so going back to a `try`/`except KeyError` structure actually seems much more performant now we're using a `WeakKeyDictionary` for the non-slotted case, and doesn't seem to cost us anything for the slotted case